### PR TITLE
Fido metadata rootca tolerant parse

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
             -   name: Setup .NET SDK 8.0
                 uses: actions/setup-dotnet@v4.0.0
                 with:
-                    dotnet-version: 8.0.200
+                    dotnet-version: 8.0.201
                     source-url: ${{ secrets.NUGET_SOURCE }}
                 env:
                     NUGET_AUTH_TOKEN: ${{ secrets.PACKAGES_TOKEN }}

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -28,7 +28,7 @@ jobs:
             -   name: Setup .NET SDK 8.0
                 uses: actions/setup-dotnet@v4.0.0
                 with:
-                    dotnet-version: 8.0.200
+                    dotnet-version: 8.0.201
                     source-url: ${{ secrets.NUGET_SOURCE }}
                 env:
                     NUGET_AUTH_TOKEN: ${{ secrets.PACKAGES_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The documentation for each project is described in its README.md file.
 ### Required dependencies
 
 - [.NET SDK 6.0.419+](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
-- [.NET SDK 8.0.200+](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+- [.NET SDK 8.0.201+](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 
 ## Tips for Contribution
 

--- a/demo/WebAuthn.Net.Demo.FidoConformance/README.md
+++ b/demo/WebAuthn.Net.Demo.FidoConformance/README.md
@@ -16,7 +16,7 @@ This project contains a demo application designed for passing the [FIDO conforma
 
 These steps need to be performed only if you have not done them before.
 
-1. Install .NET SDK versions [6.0.419+](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) and [8.0.200+](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).
+1. Install .NET SDK versions [6.0.419+](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) and [8.0.201+](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).
 2. [Trust the ASP.NET Core HTTPS development certificate](https://learn.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-8.0&tabs=visual-studio%2Clinux-ubuntu#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos)
 
 ### Starting the FIDO Conformance test

--- a/demo/WebAuthn.Net.Demo.FidoConformance/WebAuthn.Net.Demo.FidoConformance.csproj
+++ b/demo/WebAuthn.Net.Demo.FidoConformance/WebAuthn.Net.Demo.FidoConformance.csproj
@@ -35,7 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Polly" Version="8.3.0" />
+      <PackageReference Include="Polly" Version="8.3.1" />
     </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "8.0.200",
+        "version": "8.0.201",
         "rollForward": "latestFeature",
         "allowPrerelease": false
     }

--- a/src/WebAuthn.Net.Storage.MySql/WebAuthn.Net.Storage.MySql.csproj
+++ b/src/WebAuthn.Net.Storage.MySql/WebAuthn.Net.Storage.MySql.csproj
@@ -26,12 +26,12 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-        <PackageReference Include="Dapper" Version="2.1.28" />
+        <PackageReference Include="Dapper" Version="2.1.35" />
         <PackageReference Include="MySqlConnector" Version="2.2.7" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-        <PackageReference Include="Dapper" Version="2.1.28" />
+        <PackageReference Include="Dapper" Version="2.1.35" />
         <PackageReference Include="MySqlConnector" Version="2.3.5" />
     </ItemGroup>
 </Project>

--- a/src/WebAuthn.Net.Storage.PostgreSql/WebAuthn.Net.Storage.PostgreSql.csproj
+++ b/src/WebAuthn.Net.Storage.PostgreSql/WebAuthn.Net.Storage.PostgreSql.csproj
@@ -26,12 +26,12 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-        <PackageReference Include="Dapper" Version="2.1.28" />
+        <PackageReference Include="Dapper" Version="2.1.35" />
         <PackageReference Include="Npgsql" Version="7.0.6" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-        <PackageReference Include="Dapper" Version="2.1.28" />
+        <PackageReference Include="Dapper" Version="2.1.35" />
         <PackageReference Include="Npgsql" Version="8.0.2" />
     </ItemGroup>
 </Project>

--- a/src/WebAuthn.Net.Storage.SqlServer/WebAuthn.Net.Storage.SqlServer.csproj
+++ b/src/WebAuthn.Net.Storage.SqlServer/WebAuthn.Net.Storage.SqlServer.csproj
@@ -22,8 +22,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dapper" Version="2.1.28" />
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
+        <PackageReference Include="Dapper" Version="2.1.35" />
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/WebAuthn.Net/Services/FidoMetadata/Implementation/FidoMetadataDecoder/DefaultFidoMetadataDecoder.cs
+++ b/src/WebAuthn.Net/Services/FidoMetadata/Implementation/FidoMetadataDecoder/DefaultFidoMetadataDecoder.cs
@@ -713,7 +713,7 @@ public class DefaultFidoMetadataDecoder : IFidoMetadataDecoder
         result = new byte[attestationRootCertificates.Length][];
         for (var i = 0; i < attestationRootCertificates.Length; i++)
         {
-            if (!Base64Raw.TryDecode(attestationRootCertificates[i], out var attestationRootCertificate))
+            if (!Base64Raw.TryDecode(attestationRootCertificates[i].Trim(), out var attestationRootCertificate))
             {
                 result = null;
                 return false;

--- a/tests/WebAuthn.Net.Tests.Unit/WebAuthn.Net.Tests.Unit.csproj
+++ b/tests/WebAuthn.Net.Tests.Unit/WebAuthn.Net.Tests.Unit.csproj
@@ -9,13 +9,13 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="NUnit" Version="4.0.1" />
+        <PackageReference Include="NUnit" Version="4.1.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
A Trim() call has been added before parsing FIDO Root certificates due to an error in their production blob.

For OneSpan DIGIPASS FX1 BIO (aaguid 30b5035e-d297-4ff1-b00b-addc96ba6a98), one of the base64 strings in the attestationRootCertificates array starts with a tab.