### PR TITLE
[Demo] Explicit check on return type from getAuthenticatorData and getPublicKey

### DIFF
--- a/demo/WebAuthn.Net.Demo.Mvc/wwwroot/js/lib.js
+++ b/demo/WebAuthn.Net.Demo.Mvc/wwwroot/js/lib.js
@@ -133,7 +133,7 @@ const API = {
             if (newCredential.response.getAuthenticatorData) {
                 const authData = newCredential.response.getAuthenticatorData();
                 const isValid = authData instanceof ArrayBuffer;
-                if (!isValid){
+                if (!isValid) {
                     Alerts.getAuthenticatorDataInvalid();
                     return;
                 }

--- a/demo/WebAuthn.Net.Demo.Mvc/wwwroot/js/lib.js
+++ b/demo/WebAuthn.Net.Demo.Mvc/wwwroot/js/lib.js
@@ -132,7 +132,7 @@ const API = {
             let authenticatorData;
             if (newCredential.response.getAuthenticatorData) {
                 const authData = newCredential.response.getAuthenticatorData();
-                const isValid = authData instanceof "arraybuffer";
+                const isValid = authData instanceof ArrayBuffer;
                 if (!isValid){
                     Alerts.getAuthenticatorDataInvalid();
                     return;
@@ -143,7 +143,7 @@ const API = {
             let publicKey;
             if (newCredential.response.getPublicKey) {
                 const responsePublicKey = newCredential.response.getPublicKey();
-                const isValid = responsePublicKey instanceof "arraybuffer";
+                const isValid = responsePublicKey instanceof ArrayBuffer;
                 if (!isValid) {
                     Alerts.getPublicKeyInvalid();
                     return;

--- a/demo/WebAuthn.Net.Demo.Mvc/wwwroot/js/lib.js
+++ b/demo/WebAuthn.Net.Demo.Mvc/wwwroot/js/lib.js
@@ -107,7 +107,9 @@ const Alerts = {
     registerSuccess: () => alert("User registered!"),
     usernameInputEmpty: () => alert("Username input is empty"),
     credentialsGetApiNull: () => alert("navigator.credentials.get returned null"),
-    credentialsCreateApiNull: () => alert("navigator.credentials.create returned null")
+    credentialsCreateApiNull: () => alert("navigator.credentials.create returned null"),
+    getAuthenticatorDataInvalid: () => alert("Invalid data from getAuthenticatorData() method. Expected arraybuffer"),
+    getPublicKeyInvalid: () => alert("Invalid data from getPublicKey() method. Expected arraybuffer")
 };
 
 // API
@@ -127,12 +129,27 @@ const API = {
             const clientExtensionResults = newCredential.getClientExtensionResults ?
                 (newCredential.getClientExtensionResults() ?? {}) : {};
 
-            const authenticatorData = newCredential.response.getAuthenticatorData ?
-                coerceToBase64Url(newCredential.response.getAuthenticatorData()) : undefined;
+            let authenticatorData;
+            if (newCredential.response.getAuthenticatorData) {
+                const authData = newCredential.response.getAuthenticatorData();
+                const isValid = authData instanceof "arraybuffer";
+                if (!isValid){
+                    Alerts.getAuthenticatorDataInvalid();
+                    return;
+                }
+                authenticatorData = coerceToBase64Url(authData);
+            }
 
-            const responsePublicKey = newCredential.response.getPublicKey ?
-                newCredential.response.getPublicKey() : undefined;
-            const publicKey = responsePublicKey ? coerceToBase64Url(responsePublicKey) : undefined;
+            let publicKey;
+            if (newCredential.response.getPublicKey) {
+                const responsePublicKey = newCredential.response.getPublicKey();
+                const isValid = responsePublicKey instanceof "arraybuffer";
+                if (!isValid) {
+                    Alerts.getPublicKeyInvalid();
+                    return;
+                }
+                publicKey = coerceToBase64Url(responsePublicKey);
+            }
 
             const transports = newCredential.response.getTransports ?
                 newCredential.response.getTransports() : undefined;


### PR DESCRIPTION
Should fix #8

Overridden getAuthenticatorData and getPublicKey by 1Password plugin are incompatible with [Webauthn level 3 spec](https://www.w3.org/TR/webauthn-3/)

Registration become stricter and validates that returned data is ArrayBuffer type

![image](https://github.com/dodobrands/WebAuthn.Net/assets/3408281/886965c5-c748-409e-883b-93f9da683243)
