### PR TITLE
[Demo] Use username hash as userhandle

### DIFF
--- a/demo/WebAuthn.Net.Demo.Mvc/Services/Implementation/DefaultUserService.cs
+++ b/demo/WebAuthn.Net.Demo.Mvc/Services/Implementation/DefaultUserService.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json;
+﻿using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.WebUtilities;
@@ -106,7 +108,7 @@ public class DefaultUserService(IDataProtectionProvider provider)
 
     private static TypedInternalApplicationUser Create(string userName)
     {
-        var userHandle = Guid.NewGuid().ToByteArray();
+        var userHandle = SHA256.HashData(Encoding.UTF8.GetBytes(userName));
         var createdAt = DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
         return new(userHandle, userName, createdAt);
     }


### PR DESCRIPTION
Fixes #7 

Registration may fail on same username due random userHandle for same username

This PR fixes userhandle generation to use SHA256 from username instead of random Guid